### PR TITLE
Fixed extension for the last Planner version

### DIFF
--- a/estimates.js
+++ b/estimates.js
@@ -10,7 +10,7 @@ var extractFromColumnTitle = function(regexp, cardTitle) {
 };
 
 setInterval(function() {
-	var columns = $(".PlannerRoot .planTaskboardPage .boardColumn");
+	var columns = $(".PlannerRoot .tasksBoardPage .boardColumn");
 	columns.each(function() {
 		var columnTitleSection = $(this).find(".columnHeader .titleSection");
 		var columnTitleDiv = $(columnTitleSection).find(".columnTitle");

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Estimations Plugin for Microsoft Planner",
   "description": "This extension sums up numbers given in the title of Microsoft Planner cards",
-  "version": "1.5",
+  "version": "1.6",
   "short_name" : "Planner Estimations",
 
   "author": "Dirk Räbiger",


### PR DESCRIPTION
### Issue:
This extension was not working in the last Planner version. It seems that they changed a css class name.

### Solution:
Updated CSS column class names. From `.planTaskboardPage` to `.tasksBoardPage`. Tested and working.

Please merge this so everybody can continue enjoying the extension :smile: 