### PR TITLE
Fix DOM selector to target only relevant task board columns

### DIFF
--- a/estimates.js
+++ b/estimates.js
@@ -1,6 +1,6 @@
 setInterval(function() {
 // setTimeout(function() {
-	const columns = document.querySelectorAll(".PlannerRoot .planTaskBoardPage .taskBoardColumn");
+	const columns = document.querySelectorAll(".taskBoardColumn");
 	columns.forEach(function(column) {
 		let columnTitleSection = column.querySelector(".columnHeader .titleSection");
 		if (columnTitleSection === null) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Estimations Plugin for Microsoft Planner",
   "description": "This extension sums up numbers given in the title of Microsoft Planner cards",
-  "version": "1.66",
+  "version": "1.67",
   "short_name" : "Planner Estimations",
 
   "author": "Dirk Räbiger, Pablo Rivero, cmerodio@github.com",


### PR DESCRIPTION
Fixes https://github.com/drabiger/estimationsChromePlugin/issues/11

@drabiger 